### PR TITLE
[FEAT] 티켓 상세 조회 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ out/
 .vscode
 
 *.yml
+
+.env

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
+    // s3
+    implementation platform('com.amazonaws:aws-java-sdk-bom:1.12.681')
+    implementation 'com.amazonaws:aws-java-sdk-s3'
+
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 

--- a/src/main/java/org/sopt/ticketbay/domain/event/domain/enums/MainCategory.java
+++ b/src/main/java/org/sopt/ticketbay/domain/event/domain/enums/MainCategory.java
@@ -1,7 +1,9 @@
 package org.sopt.ticketbay.domain.event.domain.enums;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+@Getter
 @RequiredArgsConstructor
 public enum MainCategory {
     

--- a/src/main/java/org/sopt/ticketbay/domain/ticket/controller/TicketController.java
+++ b/src/main/java/org/sopt/ticketbay/domain/ticket/controller/TicketController.java
@@ -1,7 +1,15 @@
 package org.sopt.ticketbay.domain.ticket.controller;
 
+import static org.sopt.ticketbay.domain.ticket.controller.message.TicketSuccessCode.TICKET_DETAIL_RETRIEVED_SUCCESS;
+
 import lombok.RequiredArgsConstructor;
+import org.sopt.ticketbay.domain.ticket.controller.dto.response.TicketDetailResponse;
 import org.sopt.ticketbay.domain.ticket.service.TicketService;
+import org.sopt.ticketbay.domain.ticket.service.dto.response.TicketResult;
+import org.sopt.ticketbay.global.response.dto.ApiResponseBody;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -11,5 +19,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class TicketController {
 
     private final TicketService ticketService;
+
+    @GetMapping("/tickets/{ticketId}")
+    public ResponseEntity<ApiResponseBody<TicketDetailResponse, Void>> getTicketDetail(
+        @PathVariable Long ticketId
+    ) {
+        TicketResult ticketResult = ticketService.getTicketDetail(ticketId);
+        TicketDetailResponse resonse = TicketDetailResponse.from(ticketResult);
+
+        return ResponseEntity.ok(ApiResponseBody.ok(TICKET_DETAIL_RETRIEVED_SUCCESS, resonse));
+    }
 
 }

--- a/src/main/java/org/sopt/ticketbay/domain/ticket/controller/TicketController.java
+++ b/src/main/java/org/sopt/ticketbay/domain/ticket/controller/TicketController.java
@@ -11,6 +11,7 @@ import org.sopt.ticketbay.domain.ticket.controller.dto.response.TicketListRespon
 import org.sopt.ticketbay.domain.ticket.controller.dto.response.TicketResponse;
 import org.sopt.ticketbay.domain.ticket.controller.dto.response.TicketDetailResponse;
 import org.sopt.ticketbay.domain.ticket.service.TicketService;
+import org.sopt.ticketbay.domain.ticket.service.dto.response.TicketDetailResult;
 import org.sopt.ticketbay.domain.ticket.service.dto.response.TicketResult;
 import org.sopt.ticketbay.global.response.dto.ApiResponseBody;
 import org.springframework.http.ResponseEntity;
@@ -47,7 +48,7 @@ public class TicketController {
     public ResponseEntity<ApiResponseBody<TicketDetailResponse, Void>> getTicketDetail(
         @PathVariable Long ticketId
     ) {
-        TicketResult ticketResult = ticketService.getTicketDetail(ticketId);
+        TicketDetailResult ticketResult = ticketService.getTicketDetail(ticketId);
         TicketDetailResponse resonse = TicketDetailResponse.from(ticketResult);
 
         return ResponseEntity.ok(ApiResponseBody.ok(TICKET_DETAIL_RETRIEVED_SUCCESS, resonse));

--- a/src/main/java/org/sopt/ticketbay/domain/ticket/controller/dto/response/EventResponse.java
+++ b/src/main/java/org/sopt/ticketbay/domain/ticket/controller/dto/response/EventResponse.java
@@ -1,0 +1,25 @@
+package org.sopt.ticketbay.domain.ticket.controller.dto.response;
+
+import java.time.LocalDateTime;
+import org.sopt.ticketbay.domain.ticket.service.dto.response.EventInfo;
+
+public record EventResponse(
+    String mainCategory,
+    String subCategory,
+    String name,
+    LocalDateTime date,
+    String place,
+    String detailName
+) {
+
+    public static EventResponse from(EventInfo eventInfo) {
+        return new EventResponse(
+            eventInfo.mainCategory(),
+            eventInfo.subCategory(),
+            eventInfo.name(),
+            eventInfo.date(),
+            eventInfo.place(),
+            eventInfo.detailName()
+        );
+    }
+}

--- a/src/main/java/org/sopt/ticketbay/domain/ticket/controller/dto/response/SeatResponse.java
+++ b/src/main/java/org/sopt/ticketbay/domain/ticket/controller/dto/response/SeatResponse.java
@@ -1,0 +1,20 @@
+package org.sopt.ticketbay.domain.ticket.controller.dto.response;
+
+import org.sopt.ticketbay.domain.ticket.service.dto.response.SeatInfo;
+
+public record SeatResponse(
+    int area,
+    int seatColumn,
+    String seatType,
+    String seatImageUrl
+) {
+
+    public static SeatResponse from(SeatInfo seatInfo) {
+        return new SeatResponse(
+            seatInfo.area(),
+            seatInfo.seatColumn(),
+            seatInfo.seatType(),
+            seatInfo.seatImageUrl()
+        );
+    }
+}

--- a/src/main/java/org/sopt/ticketbay/domain/ticket/controller/dto/response/TicketDetailResponse.java
+++ b/src/main/java/org/sopt/ticketbay/domain/ticket/controller/dto/response/TicketDetailResponse.java
@@ -1,56 +1,29 @@
 package org.sopt.ticketbay.domain.ticket.controller.dto.response;
 
-import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
-import org.sopt.ticketbay.domain.ticket.service.dto.response.TicketResult;
-
+import org.sopt.ticketbay.domain.ticket.service.dto.response.TicketDetailResult;
 
 public record TicketDetailResponse(
     Long id,
     Long productNumber,
-    String mainCategory,
-    String subCategory,
-    String name,
-    LocalDateTime date,
-    String place,
-    String detailName,
-    int area,
-    int seatColumn,
-    String seatType,
-    String seatImageUrl,
+    EventResponse event,
+    SeatResponse seat,
     boolean status,
     int pricePerTicket,
     int amount,
     LocalDateTime createdAt
 ) {
 
-    public static TicketDetailResponse from(TicketResult result) {
+    public static TicketDetailResponse from(TicketDetailResult result) {
         return new TicketDetailResponse(
             result.id(),
             result.productNumber(),
-            result.mainCategory(),
-            result.subCategory(),
-            result.name(),
-            toLocalDateTime(result.date()),
-            result.place(),
-            result.detailName(),
-            result.area(),
-            result.seatColumn(),
-            result.seatType(),
-            result.seatImageUrl(),
+            EventResponse.from(result.event()),
+            SeatResponse.from(result.seat()),
             result.status(),
             result.pricePerTicket(),
             result.amount(),
-            toLocalDateTime(result.createdAt())
+            result.createdAt()
         );
-    }
-
-    private static LocalDateTime toLocalDateTime(Instant instant) {
-        if (instant == null) {
-            return null;
-        }
-
-        return LocalDateTime.ofInstant(instant, ZoneId.of("Asia/Seoul"));
     }
 }

--- a/src/main/java/org/sopt/ticketbay/domain/ticket/controller/dto/response/TicketDetailResponse.java
+++ b/src/main/java/org/sopt/ticketbay/domain/ticket/controller/dto/response/TicketDetailResponse.java
@@ -1,0 +1,56 @@
+package org.sopt.ticketbay.domain.ticket.controller.dto.response;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import org.sopt.ticketbay.domain.ticket.service.dto.response.TicketResult;
+
+
+public record TicketDetailResponse(
+    Long id,
+    Long productNumber,
+    String mainCategory,
+    String subCategory,
+    String name,
+    LocalDateTime date,
+    String place,
+    String detailName,
+    int area,
+    int seatColumn,
+    String seatType,
+    String seatImageUrl,
+    boolean status,
+    int pricePerTicket,
+    int amount,
+    LocalDateTime createdAt
+) {
+
+    public static TicketDetailResponse from(TicketResult result) {
+        return new TicketDetailResponse(
+            result.id(),
+            result.productNumber(),
+            result.mainCategory(),
+            result.subCategory(),
+            result.name(),
+            toLocalDateTime(result.date()),
+            result.place(),
+            result.detailName(),
+            result.area(),
+            result.seatColumn(),
+            result.seatType(),
+            result.seatImageUrl(),
+            result.status(),
+            result.pricePerTicket(),
+            result.amount(),
+            toLocalDateTime(result.createdAt())
+        );
+    }
+
+    private static LocalDateTime toLocalDateTime(Instant instant) {
+        if (instant == null) {
+            return null;
+        }
+
+        return LocalDateTime.ofInstant(instant, ZoneId.of("Asia/Seoul"));
+    }
+}

--- a/src/main/java/org/sopt/ticketbay/domain/ticket/controller/dto/response/TicketListResponse.java
+++ b/src/main/java/org/sopt/ticketbay/domain/ticket/controller/dto/response/TicketListResponse.java
@@ -5,6 +5,7 @@ import java.util.List;
 public record TicketListResponse(
     List<TicketResponse> tickets
 ) {
+
     public static TicketListResponse from(List<TicketResponse> ticketResponseList) {
         return new TicketListResponse(ticketResponseList);
     }

--- a/src/main/java/org/sopt/ticketbay/domain/ticket/controller/dto/response/TicketResponse.java
+++ b/src/main/java/org/sopt/ticketbay/domain/ticket/controller/dto/response/TicketResponse.java
@@ -26,4 +26,3 @@ public record TicketResponse(
         );
     }
 }
-

--- a/src/main/java/org/sopt/ticketbay/domain/ticket/controller/message/TicketSuccessCode.java
+++ b/src/main/java/org/sopt/ticketbay/domain/ticket/controller/message/TicketSuccessCode.java
@@ -8,6 +8,8 @@ import org.sopt.ticketbay.global.response.code.SuccessCode;
 @RequiredArgsConstructor
 public enum TicketSuccessCode implements SuccessCode {
 
+    // 200
+    TICKET_DETAIL_RETRIEVED_SUCCESS(200, "TIC_200_002", "성공적으로 티켓 상세 내용을 조회했습니다."),
     ;
 
     private final int status;

--- a/src/main/java/org/sopt/ticketbay/domain/ticket/domain/exception/TicketErrorCode.java
+++ b/src/main/java/org/sopt/ticketbay/domain/ticket/domain/exception/TicketErrorCode.java
@@ -8,6 +8,8 @@ import org.sopt.ticketbay.global.response.code.ErrorCode;
 @RequiredArgsConstructor
 public enum TicketErrorCode implements ErrorCode {
 
+    // 404
+    TICKET_NOT_FOUND(404, "TIC_404_001", "해당 티켓을 찾을 수 없습니다."),
     ;
 
     private final int status;

--- a/src/main/java/org/sopt/ticketbay/domain/ticket/service/TicketService.java
+++ b/src/main/java/org/sopt/ticketbay/domain/ticket/service/TicketService.java
@@ -10,10 +10,13 @@ import org.sopt.ticketbay.domain.ticket.domain.Ticket;
 import org.sopt.ticketbay.domain.ticket.domain.exception.TicketException;
 import org.sopt.ticketbay.domain.ticket.repository.TicketCustomRepository;
 import org.sopt.ticketbay.domain.ticket.repository.TicketRepository;
+import org.sopt.ticketbay.domain.ticket.service.dto.response.TicketDetailResult;
 import org.sopt.ticketbay.domain.ticket.service.dto.response.TicketResult;
 import org.sopt.ticketbay.global.s3.S3Service;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Service
 public class TicketService {
@@ -21,6 +24,7 @@ public class TicketService {
     private final TicketRepository ticketRepository;
     private final TicketCustomRepository ticketCustomRepository;
     private final EventValidator eventValidator;
+    private final S3Service s3Service;
 
     public List<TicketResult> getTickets(Long eventId, LocalDate date) {
         eventValidator.validateEvent(eventId);
@@ -30,14 +34,13 @@ public class TicketService {
             .map(TicketResult::from)
             .toList();
     }
-    private final S3Service s3Service;
 
-    public TicketResult getTicketDetail(Long ticketId) {
+    public TicketDetailResult getTicketDetail(Long ticketId) {
         Ticket ticket = ticketRepository.findById(ticketId)
             .orElseThrow(() -> new TicketException(TICKET_NOT_FOUND));
         String imageUrl = s3Service.generatePresignedUrl(ticket.getSeat().getImageKey());
 
-        return TicketResult.of(ticket, imageUrl);
+        return TicketDetailResult.from(ticket, imageUrl);
     }
 
 }

--- a/src/main/java/org/sopt/ticketbay/domain/ticket/service/TicketService.java
+++ b/src/main/java/org/sopt/ticketbay/domain/ticket/service/TicketService.java
@@ -1,7 +1,13 @@
 package org.sopt.ticketbay.domain.ticket.service;
 
+import static org.sopt.ticketbay.domain.ticket.domain.exception.TicketErrorCode.TICKET_NOT_FOUND;
+
 import lombok.RequiredArgsConstructor;
+import org.sopt.ticketbay.domain.ticket.domain.Ticket;
+import org.sopt.ticketbay.domain.ticket.domain.exception.TicketException;
 import org.sopt.ticketbay.domain.ticket.repository.TicketRepository;
+import org.sopt.ticketbay.domain.ticket.service.dto.response.TicketResult;
+import org.sopt.ticketbay.global.s3.S3Service;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -9,5 +15,14 @@ import org.springframework.stereotype.Service;
 public class TicketService {
 
     private final TicketRepository ticketRepository;
+    private final S3Service s3Service;
+
+    public TicketResult getTicketDetail(Long ticketId) {
+        Ticket ticket = ticketRepository.findById(ticketId)
+            .orElseThrow(() -> new TicketException(TICKET_NOT_FOUND));
+        String imageUrl = s3Service.generatePresignedUrl(ticket.getSeat().getImageKey());
+
+        return TicketResult.of(ticket, imageUrl);
+    }
 
 }

--- a/src/main/java/org/sopt/ticketbay/domain/ticket/service/dto/response/EventInfo.java
+++ b/src/main/java/org/sopt/ticketbay/domain/ticket/service/dto/response/EventInfo.java
@@ -1,0 +1,30 @@
+package org.sopt.ticketbay.domain.ticket.service.dto.response;
+
+import java.time.LocalDateTime;
+import org.sopt.ticketbay.domain.event.domain.Event;
+
+public record EventInfo(
+    Long id,
+    String mainCategory,
+    String subCategory,
+    String name,
+    LocalDateTime date,
+    String place,
+    String detailName
+) {
+
+    public static EventInfo from(Event event) {
+        return new EventInfo(
+            event.getId(),
+            event.getMainCategory().getName(),
+            event.getSubCategory(),
+            event.getName(),
+            LocalDateTime.ofInstant(
+                event.getEventDate(),
+                java.time.ZoneId.of("Asia/Seoul")
+            ),
+            event.getPlace(),
+            event.getDetailName()
+        );
+    }
+}

--- a/src/main/java/org/sopt/ticketbay/domain/ticket/service/dto/response/SeatInfo.java
+++ b/src/main/java/org/sopt/ticketbay/domain/ticket/service/dto/response/SeatInfo.java
@@ -1,0 +1,22 @@
+package org.sopt.ticketbay.domain.ticket.service.dto.response;
+
+import org.sopt.ticketbay.domain.seat.domain.Seat;
+
+public record SeatInfo(
+    Long id,
+    int area,
+    int seatColumn,
+    String seatType,
+    String seatImageUrl
+) {
+
+    public static SeatInfo from(Seat seat, String seatImageUrl) {
+        return new SeatInfo(
+            seat.getId(),
+            seat.getArea(),
+            seat.getSeatColumn(),
+            seat.getSeatType(),
+            seatImageUrl
+        );
+    }
+}

--- a/src/main/java/org/sopt/ticketbay/domain/ticket/service/dto/response/TicketDetailResult.java
+++ b/src/main/java/org/sopt/ticketbay/domain/ticket/service/dto/response/TicketDetailResult.java
@@ -1,0 +1,30 @@
+package org.sopt.ticketbay.domain.ticket.service.dto.response;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import org.sopt.ticketbay.domain.ticket.domain.Ticket;
+
+public record TicketDetailResult(
+    Long id,
+    Long productNumber,
+    EventInfo event,
+    SeatInfo seat,
+    boolean status,
+    int pricePerTicket,
+    int amount,
+    LocalDateTime createdAt
+) {
+
+    public static TicketDetailResult from(Ticket ticket, String seatImageUrl) {
+        return new TicketDetailResult(
+            ticket.getId(),
+            ticket.getProductNumber(),
+            EventInfo.from(ticket.getEvent()),
+            SeatInfo.from(ticket.getSeat(), seatImageUrl),
+            ticket.isStatus(),
+            ticket.getPrice(),
+            ticket.getAmount(),
+            LocalDateTime.ofInstant(ticket.getCreatedAt(), ZoneOffset.UTC)
+        );
+    }
+}

--- a/src/main/java/org/sopt/ticketbay/domain/ticket/service/dto/response/TicketResult.java
+++ b/src/main/java/org/sopt/ticketbay/domain/ticket/service/dto/response/TicketResult.java
@@ -1,0 +1,45 @@
+package org.sopt.ticketbay.domain.ticket.service.dto.response;
+
+import java.time.Instant;
+import org.sopt.ticketbay.domain.ticket.domain.Ticket;
+
+public record TicketResult(
+    Long id,
+    Long productNumber,
+    String mainCategory,
+    String subCategory,
+    String name,
+    Instant date,
+    String place,
+    String detailName,
+    int area,
+    int seatColumn,
+    String seatType,
+    String seatImageUrl,
+    boolean status,
+    int pricePerTicket,
+    int amount,
+    Instant createdAt
+) {
+
+    public static TicketResult of(Ticket ticket, String seatImageUrl) {
+        return new TicketResult(
+            ticket.getId(),
+            ticket.getProductNumber(),
+            ticket.getEvent().getMainCategory().toString(),
+            ticket.getEvent().getSubCategory(),
+            ticket.getEvent().getName(),
+            ticket.getEvent().getEventDate(),
+            ticket.getEvent().getPlace(),
+            ticket.getEvent().getDetailName(),
+            ticket.getSeat().getArea(),
+            ticket.getSeat().getSeatColumn(),
+            ticket.getSeat().getSeatType(),
+            seatImageUrl,
+            ticket.isStatus(),
+            ticket.getPrice(),
+            ticket.getAmount(),
+            ticket.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/org/sopt/ticketbay/global/config/s3/S3Config.java
+++ b/src/main/java/org/sopt/ticketbay/global/config/s3/S3Config.java
@@ -1,0 +1,45 @@
+package org.sopt.ticketbay.global.config.s3;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Value("${cloud.aws.credentials.access-key:}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key:}")
+    private String secretKey;
+
+    @Bean
+    @Profile("local")
+    public AmazonS3 amazonS3Local() {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder.standard()
+            .withRegion(region)
+            .withCredentials(new AWSStaticCredentialsProvider(credentials))
+            .build();
+    }
+
+    @Bean
+    @Profile("prod")
+    public AmazonS3 amazonS3Prod() {
+        return AmazonS3ClientBuilder.standard()
+            .withRegion(region)
+            .withCredentials(DefaultAWSCredentialsProviderChain.getInstance())
+            .build();
+    }
+}

--- a/src/main/java/org/sopt/ticketbay/global/s3/S3Service.java
+++ b/src/main/java/org/sopt/ticketbay/global/s3/S3Service.java
@@ -1,0 +1,29 @@
+package org.sopt.ticketbay.global.s3;
+
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import java.util.Date;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public String generatePresignedUrl(String key) {
+        Date expiration = new Date(System.currentTimeMillis() + 1000 * 60 * 60); // 1시간
+        GeneratePresignedUrlRequest request = new GeneratePresignedUrlRequest(bucket, key)
+            .withMethod(HttpMethod.GET)
+            .withExpiration(expiration);
+
+        return amazonS3.generatePresignedUrl(request).toString();
+    }
+
+}


### PR DESCRIPTION
# ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- [x] 리뷰어를 지정해 주세요.
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.
- [x] Assignee 지정해 주세요.
- [x] 라벨 지정해 주세요.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #6

### ⭐️ 구현 내용
- [x] 티켓 상세 조회

---

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
#### 1️⃣ 이미지 조회 시 S3 도입
관련해서 S3 의존성을 추가하였고, local, prod 환경 별 S3Config를 도입했습니다. 이를 위해 application.yml, application-local.yml, applicaiton-prod.yml, .env를 도입하였으며, 관련 설정은 노션에 올려두겠습니다! 또한, 이미지 url을 그대로 반환하면 조회가 되지 않는 문제가 있어 일정 시간 동안만 이미지에 접근 가능한 방식으로 구현하였습니다.

#### 2️⃣ 시간 관련 값 반환 시 Instant 대신 LocalDateTime 을 사용했습니다.
#7 에서 언급한 바와 같이, 프론트 분들의 개발 시 포맷팅이 더 용이하도록 Instant 대신 LocalDateTime을 사용했습니다!

#### 3️⃣ DTO 분리 고민
현재 #7 도 그렇고, 반환 값의 data에 모든 필요한 데이터를 도메인 별 DTO 구분 없이 반환하고 있는데요, 백엔드 입장에서는 DTO 별로 분리해서 주는 것이 맞다고 생각하기는 하는데 현재 프론트 분들의 볼륨이 큰 상태라 현재처럼 DTO 구분 없이 보내드리는 게 맞을지에 대한 고민이 듭니다...!