### PR TITLE
[FEAT] 최근 조회한 이벤트 목록 조회

### DIFF
--- a/src/main/java/org/sopt/ticketbay/domain/history/controller/HistoryController.java
+++ b/src/main/java/org/sopt/ticketbay/domain/history/controller/HistoryController.java
@@ -3,13 +3,16 @@ package org.sopt.ticketbay.domain.history.controller;
 import lombok.RequiredArgsConstructor;
 import org.sopt.ticketbay.domain.history.controller.dto.response.HistoryResponse;
 import org.sopt.ticketbay.domain.history.controller.dto.response.RecentHistoryListResponse;
-import org.sopt.ticketbay.domain.history.domain.History;
 import org.sopt.ticketbay.domain.history.service.HistoryService;
 import org.sopt.ticketbay.domain.user.validator.UserValidator;
 import org.sopt.ticketbay.global.response.dto.ApiResponseBody;
-import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 import static org.sopt.ticketbay.domain.history.controller.message.HistorySuccessCode.HISTORY_LIST_RETRIEVED_SUCCESS;
 
@@ -24,20 +27,16 @@ public class HistoryController {
     // 최근 조회 내역 리스트 조회 API
     @GetMapping("/users/{userId}/recent")
     public ResponseEntity<ApiResponseBody<RecentHistoryListResponse, Void>> getRecentHistories(
-            @PathVariable Long userId,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size
+            @PathVariable Long userId
     ) {
         userValidator.validateUser(userId);
-        Page<History> historiesPage = historyService.getRecentHistories(userId, page, size);
 
-        RecentHistoryListResponse response = RecentHistoryListResponse.from(
-                historiesPage.map(HistoryResponse::from).toList(),
-                historiesPage.getNumber(),
-                historiesPage.getSize(),
-                historiesPage.getTotalElements(),
-                historiesPage.getTotalPages()
-        );
+        List<HistoryResponse> historyResponses = historyService.getAllHistories(userId)
+                .stream()
+                .map(HistoryResponse::from)
+                .toList();
+
+        RecentHistoryListResponse response = new RecentHistoryListResponse(historyResponses);
 
         return ResponseEntity.ok(ApiResponseBody.ok(HISTORY_LIST_RETRIEVED_SUCCESS, response));
     }

--- a/src/main/java/org/sopt/ticketbay/domain/history/controller/HistoryController.java
+++ b/src/main/java/org/sopt/ticketbay/domain/history/controller/HistoryController.java
@@ -1,9 +1,17 @@
 package org.sopt.ticketbay.domain.history.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.ticketbay.domain.history.controller.dto.response.HistoryResponse;
+import org.sopt.ticketbay.domain.history.controller.dto.response.RecentHistoryListResponse;
+import org.sopt.ticketbay.domain.history.domain.History;
 import org.sopt.ticketbay.domain.history.service.HistoryService;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.sopt.ticketbay.domain.user.validator.UserValidator;
+import org.sopt.ticketbay.global.response.dto.ApiResponseBody;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import static org.sopt.ticketbay.domain.history.controller.message.HistorySuccessCode.HISTORY_LIST_RETRIEVED_SUCCESS;
 
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
@@ -11,5 +19,27 @@ import org.springframework.web.bind.annotation.RestController;
 public class HistoryController {
 
     private final HistoryService historyService;
+    private final UserValidator userValidator;
+
+    // 최근 조회 내역 리스트 조회 API
+    @GetMapping("/users/{userId}/recent")
+    public ResponseEntity<ApiResponseBody<RecentHistoryListResponse, Void>> getRecentHistories(
+            @PathVariable Long userId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        userValidator.validateUser(userId);
+        Page<History> historiesPage = historyService.getRecentHistories(userId, page, size);
+
+        RecentHistoryListResponse response = RecentHistoryListResponse.from(
+                historiesPage.map(HistoryResponse::from).toList(),
+                historiesPage.getNumber(),
+                historiesPage.getSize(),
+                historiesPage.getTotalElements(),
+                historiesPage.getTotalPages()
+        );
+
+        return ResponseEntity.ok(ApiResponseBody.ok(HISTORY_LIST_RETRIEVED_SUCCESS, response));
+    }
 
 }

--- a/src/main/java/org/sopt/ticketbay/domain/history/controller/HistoryController.java
+++ b/src/main/java/org/sopt/ticketbay/domain/history/controller/HistoryController.java
@@ -1,10 +1,9 @@
 package org.sopt.ticketbay.domain.history.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.sopt.ticketbay.domain.history.controller.dto.response.HistoryResponse;
 import org.sopt.ticketbay.domain.history.controller.dto.response.HistoryListResponse;
+import org.sopt.ticketbay.domain.history.controller.dto.response.HistoryResponse;
 import org.sopt.ticketbay.domain.history.service.HistoryService;
-import org.sopt.ticketbay.domain.user.validator.UserValidator;
 import org.sopt.ticketbay.global.response.dto.ApiResponseBody;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,14 +21,11 @@ import static org.sopt.ticketbay.domain.history.controller.message.HistorySucces
 public class HistoryController {
 
     private final HistoryService historyService;
-    private final UserValidator userValidator;
 
     @GetMapping("/users/{userId}/recent")
     public ResponseEntity<ApiResponseBody<HistoryListResponse, Void>> getRecentHistories(
             @PathVariable Long userId
     ) {
-        userValidator.validateUser(userId);
-
         List<HistoryResponse> historyResponses = historyService.getAllHistories(userId)
                 .stream()
                 .map(HistoryResponse::from)

--- a/src/main/java/org/sopt/ticketbay/domain/history/controller/HistoryController.java
+++ b/src/main/java/org/sopt/ticketbay/domain/history/controller/HistoryController.java
@@ -24,7 +24,6 @@ public class HistoryController {
     private final HistoryService historyService;
     private final UserValidator userValidator;
 
-    // 최근 조회 내역 리스트 조회 API
     @GetMapping("/users/{userId}/recent")
     public ResponseEntity<ApiResponseBody<HistoryListResponse, Void>> getRecentHistories(
             @PathVariable Long userId

--- a/src/main/java/org/sopt/ticketbay/domain/history/controller/HistoryController.java
+++ b/src/main/java/org/sopt/ticketbay/domain/history/controller/HistoryController.java
@@ -2,7 +2,7 @@ package org.sopt.ticketbay.domain.history.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.ticketbay.domain.history.controller.dto.response.HistoryResponse;
-import org.sopt.ticketbay.domain.history.controller.dto.response.RecentHistoryListResponse;
+import org.sopt.ticketbay.domain.history.controller.dto.response.HistoryListResponse;
 import org.sopt.ticketbay.domain.history.service.HistoryService;
 import org.sopt.ticketbay.domain.user.validator.UserValidator;
 import org.sopt.ticketbay.global.response.dto.ApiResponseBody;
@@ -26,7 +26,7 @@ public class HistoryController {
 
     // 최근 조회 내역 리스트 조회 API
     @GetMapping("/users/{userId}/recent")
-    public ResponseEntity<ApiResponseBody<RecentHistoryListResponse, Void>> getRecentHistories(
+    public ResponseEntity<ApiResponseBody<HistoryListResponse, Void>> getRecentHistories(
             @PathVariable Long userId
     ) {
         userValidator.validateUser(userId);
@@ -36,7 +36,7 @@ public class HistoryController {
                 .map(HistoryResponse::from)
                 .toList();
 
-        RecentHistoryListResponse response = new RecentHistoryListResponse(historyResponses);
+        HistoryListResponse response = new HistoryListResponse(historyResponses);
 
         return ResponseEntity.ok(ApiResponseBody.ok(HISTORY_LIST_RETRIEVED_SUCCESS, response));
     }

--- a/src/main/java/org/sopt/ticketbay/domain/history/controller/dto/response/HistoryListResponse.java
+++ b/src/main/java/org/sopt/ticketbay/domain/history/controller/dto/response/HistoryListResponse.java
@@ -2,10 +2,10 @@ package org.sopt.ticketbay.domain.history.controller.dto.response;
 
 import java.util.List;
 
-public record RecentHistoryListResponse(
+public record HistoryListResponse(
         List<HistoryResponse> histories
 ) {
-    public RecentHistoryListResponse(List<HistoryResponse> histories) {
+    public HistoryListResponse(List<HistoryResponse> histories) {
         this.histories = histories;
     }
 }

--- a/src/main/java/org/sopt/ticketbay/domain/history/controller/dto/response/HistoryResponse.java
+++ b/src/main/java/org/sopt/ticketbay/domain/history/controller/dto/response/HistoryResponse.java
@@ -1,0 +1,19 @@
+package org.sopt.ticketbay.domain.history.controller.dto.response;
+
+import org.sopt.ticketbay.domain.history.domain.History;
+
+import java.time.Instant;
+
+public record HistoryResponse(
+        Long eventId,
+        String name,
+        Instant lastViewedAt
+) {
+    public static HistoryResponse from(History history) {
+        return new HistoryResponse(
+                history.getEvent().getId(),
+                history.getEvent().getName(),
+                history.getLastViewedAt()
+        );
+    }
+}

--- a/src/main/java/org/sopt/ticketbay/domain/history/controller/dto/response/RecentHistoryListResponse.java
+++ b/src/main/java/org/sopt/ticketbay/domain/history/controller/dto/response/RecentHistoryListResponse.java
@@ -3,17 +3,9 @@ package org.sopt.ticketbay.domain.history.controller.dto.response;
 import java.util.List;
 
 public record RecentHistoryListResponse(
-        List<HistoryResponse> histories,
-        int page,
-        int size,
-        long totalElements,
-        int totalPages
+        List<HistoryResponse> histories
 ) {
-    public static RecentHistoryListResponse from(List<HistoryResponse> historyResponses,
-                                                 int page,
-                                                 int size,
-                                                 long totalElements,
-                                                 int totalPages) {
-        return new RecentHistoryListResponse(historyResponses, page, size, totalElements, totalPages);
+    public RecentHistoryListResponse(List<HistoryResponse> histories) {
+        this.histories = histories;
     }
 }

--- a/src/main/java/org/sopt/ticketbay/domain/history/controller/dto/response/RecentHistoryListResponse.java
+++ b/src/main/java/org/sopt/ticketbay/domain/history/controller/dto/response/RecentHistoryListResponse.java
@@ -1,0 +1,19 @@
+package org.sopt.ticketbay.domain.history.controller.dto.response;
+
+import java.util.List;
+
+public record RecentHistoryListResponse(
+        List<HistoryResponse> histories,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages
+) {
+    public static RecentHistoryListResponse from(List<HistoryResponse> historyResponses,
+                                                 int page,
+                                                 int size,
+                                                 long totalElements,
+                                                 int totalPages) {
+        return new RecentHistoryListResponse(historyResponses, page, size, totalElements, totalPages);
+    }
+}

--- a/src/main/java/org/sopt/ticketbay/domain/history/controller/message/HistorySuccessCode.java
+++ b/src/main/java/org/sopt/ticketbay/domain/history/controller/message/HistorySuccessCode.java
@@ -8,6 +8,8 @@ import org.sopt.ticketbay.global.response.code.SuccessCode;
 @RequiredArgsConstructor
 public enum HistorySuccessCode implements SuccessCode {
 
+    HISTORY_LIST_RETRIEVED_SUCCESS(200, "HIS_200_001", "성공적으로 최근 조회 목록을 조회했습니다.")
+
     ;
 
     private final int status;

--- a/src/main/java/org/sopt/ticketbay/domain/history/repository/HistoryRepository.java
+++ b/src/main/java/org/sopt/ticketbay/domain/history/repository/HistoryRepository.java
@@ -2,11 +2,12 @@ package org.sopt.ticketbay.domain.history.repository;
 
 import org.sopt.ticketbay.domain.history.domain.History;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 public interface HistoryRepository extends JpaRepository<History, Long> {
 
-    Page<History> findRecentHistoryByUser(Long userId, Pageable pageable);
+    List<History> findAllByUserOrderByLastViewedAsc(Long userId);
 
 }

--- a/src/main/java/org/sopt/ticketbay/domain/history/repository/HistoryRepository.java
+++ b/src/main/java/org/sopt/ticketbay/domain/history/repository/HistoryRepository.java
@@ -1,8 +1,12 @@
 package org.sopt.ticketbay.domain.history.repository;
 
 import org.sopt.ticketbay.domain.history.domain.History;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface HistoryRepository extends JpaRepository<History, Long> {
+
+    Page<History> findRecentHistoryByUser(Long userId, Pageable pageable);
 
 }

--- a/src/main/java/org/sopt/ticketbay/domain/history/repository/HistoryRepository.java
+++ b/src/main/java/org/sopt/ticketbay/domain/history/repository/HistoryRepository.java
@@ -8,6 +8,6 @@ import java.util.List;
 
 public interface HistoryRepository extends JpaRepository<History, Long> {
 
-    List<History> findAllByUserOrderByLastViewedAsc(Long userId);
+    List<History> findAllByUserOrderByLastViewedDesc(Long userId);
 
 }

--- a/src/main/java/org/sopt/ticketbay/domain/history/repository/HistoryRepository.java
+++ b/src/main/java/org/sopt/ticketbay/domain/history/repository/HistoryRepository.java
@@ -1,12 +1,10 @@
 package org.sopt.ticketbay.domain.history.repository;
 
 import org.sopt.ticketbay.domain.history.domain.History;
-import org.springframework.data.domain.Page;
-import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface HistoryRepository extends JpaRepository<History, Long> {
+public interface HistoryRepository {
 
     List<History> findAllByUserOrderByLastViewedDesc(Long userId);
 

--- a/src/main/java/org/sopt/ticketbay/domain/history/repository/HistoryRepositoryImpl.java
+++ b/src/main/java/org/sopt/ticketbay/domain/history/repository/HistoryRepositoryImpl.java
@@ -1,0 +1,39 @@
+package org.sopt.ticketbay.domain.history.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.sopt.ticketbay.domain.history.domain.History;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Repository
+public class HistoryRepositoryImpl {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    Page<History> findRecentHistoryByUser(Long userId, Pageable pageable){
+        QHistory history = QHistory.history;
+
+        List<History> historyList = jpaQueryFactory
+                .selectFrom(history)
+                .where(history.user.id.eq(userId))
+                .orderBy(history.lastViewedAt.desc()) // 최신순
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        long total = jpaQueryFactory
+                .select(history.count())
+                .from(history)
+                .where(history.user.id.eq(userId))
+                .fetchOne();
+
+        return new PageImpl<>(historyList, pageable, total);
+    };
+
+}

--- a/src/main/java/org/sopt/ticketbay/domain/history/repository/HistoryRepositoryImpl.java
+++ b/src/main/java/org/sopt/ticketbay/domain/history/repository/HistoryRepositoryImpl.java
@@ -3,9 +3,6 @@ package org.sopt.ticketbay.domain.history.repository;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.sopt.ticketbay.domain.history.domain.History;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -16,24 +13,14 @@ public class HistoryRepositoryImpl {
 
     private final JPAQueryFactory jpaQueryFactory;
 
-    Page<History> findRecentHistoryByUser(Long userId, Pageable pageable){
+    public List<History> findAllByUserOrderByLastViewedAsc(Long userId) {
         QHistory history = QHistory.history;
 
-        List<History> historyList = jpaQueryFactory
+        return jpaQueryFactory
                 .selectFrom(history)
                 .where(history.user.id.eq(userId))
-                .orderBy(history.lastViewedAt.desc()) // 최신순
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
+                .orderBy(history.lastViewedAt.asc()) // 최근 조회 -> 이전 조회
                 .fetch();
-
-        long total = jpaQueryFactory
-                .select(history.count())
-                .from(history)
-                .where(history.user.id.eq(userId))
-                .fetchOne();
-
-        return new PageImpl<>(historyList, pageable, total);
-    };
+    }
 
 }

--- a/src/main/java/org/sopt/ticketbay/domain/history/repository/HistoryRepositoryImpl.java
+++ b/src/main/java/org/sopt/ticketbay/domain/history/repository/HistoryRepositoryImpl.java
@@ -1,5 +1,7 @@
 package org.sopt.ticketbay.domain.history.repository;
 
+import static org.sopt.ticketbay.domain.ticket.domain.QHistory.history;
+
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.sopt.ticketbay.domain.history.domain.History;

--- a/src/main/java/org/sopt/ticketbay/domain/history/repository/HistoryRepositoryImpl.java
+++ b/src/main/java/org/sopt/ticketbay/domain/history/repository/HistoryRepositoryImpl.java
@@ -13,13 +13,11 @@ public class HistoryRepositoryImpl {
 
     private final JPAQueryFactory jpaQueryFactory;
 
-    public List<History> findAllByUserOrderByLastViewedAsc(Long userId) {
-        QHistory history = QHistory.history;
-
+    public List<History> findAllByUserOrderByLastViewedDesc(Long userId) {
         return jpaQueryFactory
                 .selectFrom(history)
                 .where(history.user.id.eq(userId))
-                .orderBy(history.lastViewedAt.asc()) // 최근 조회 -> 이전 조회
+                .orderBy(history.lastViewedAt.desc()) // 최근 조회 -> 이전 조회
                 .fetch();
     }
 

--- a/src/main/java/org/sopt/ticketbay/domain/history/service/HistoryService.java
+++ b/src/main/java/org/sopt/ticketbay/domain/history/service/HistoryService.java
@@ -14,7 +14,7 @@ public class HistoryService {
     private HistoryRepository historyRepository;
 
     public List<History> getAllHistories(Long userId) {
-        return historyRepository.findAllByUserOrderByLastViewedAsc(userId);
+        return historyRepository.findAllByUserOrderByLastViewedDesc(userId);
     }
 
 }

--- a/src/main/java/org/sopt/ticketbay/domain/history/service/HistoryService.java
+++ b/src/main/java/org/sopt/ticketbay/domain/history/service/HistoryService.java
@@ -1,7 +1,10 @@
 package org.sopt.ticketbay.domain.history.service;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.ticketbay.domain.history.domain.History;
 import org.sopt.ticketbay.domain.history.repository.HistoryRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -9,5 +12,9 @@ import org.springframework.stereotype.Service;
 public class HistoryService {
 
     private HistoryRepository historyRepository;
+
+    public Page<History> getRecentHistories(Long userId, int page, int size) {
+        return historyRepository.findRecentHistoryByUser(userId, PageRequest.of(page, size));
+    }
 
 }

--- a/src/main/java/org/sopt/ticketbay/domain/history/service/HistoryService.java
+++ b/src/main/java/org/sopt/ticketbay/domain/history/service/HistoryService.java
@@ -3,9 +3,9 @@ package org.sopt.ticketbay.domain.history.service;
 import lombok.RequiredArgsConstructor;
 import org.sopt.ticketbay.domain.history.domain.History;
 import org.sopt.ticketbay.domain.history.repository.HistoryRepository;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @Service
@@ -13,8 +13,8 @@ public class HistoryService {
 
     private HistoryRepository historyRepository;
 
-    public Page<History> getRecentHistories(Long userId, int page, int size) {
-        return historyRepository.findRecentHistoryByUser(userId, PageRequest.of(page, size));
+    public List<History> getAllHistories(Long userId) {
+        return historyRepository.findAllByUserOrderByLastViewedAsc(userId);
     }
 
 }

--- a/src/main/java/org/sopt/ticketbay/domain/history/service/HistoryService.java
+++ b/src/main/java/org/sopt/ticketbay/domain/history/service/HistoryService.java
@@ -3,6 +3,7 @@ package org.sopt.ticketbay.domain.history.service;
 import lombok.RequiredArgsConstructor;
 import org.sopt.ticketbay.domain.history.domain.History;
 import org.sopt.ticketbay.domain.history.repository.HistoryRepository;
+import org.sopt.ticketbay.domain.user.validator.UserValidator;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -12,8 +13,11 @@ import java.util.List;
 public class HistoryService {
 
     private HistoryRepository historyRepository;
+    private final UserValidator userValidator;
 
     public List<History> getAllHistories(Long userId) {
+        userValidator.validateUser(userId);
+
         return historyRepository.findAllByUserOrderByLastViewedDesc(userId);
     }
 

--- a/src/main/java/org/sopt/ticketbay/domain/user/domain/exception/UserErrorCode.java
+++ b/src/main/java/org/sopt/ticketbay/domain/user/domain/exception/UserErrorCode.java
@@ -9,7 +9,7 @@ import org.sopt.ticketbay.global.response.code.ErrorCode;
 public enum UserErrorCode implements ErrorCode {
 
     // 404 잘못된 요청
-    USER_NOT_FOUND(404, "USER_404_001", "존재하지 않는 유저입니다."),
+    USER_NOT_FOUND(404, "USE_404_001", "존재하지 않는 유저입니다."),
     ;
 
     private final int status;

--- a/src/main/java/org/sopt/ticketbay/domain/user/domain/exception/UserErrorCode.java
+++ b/src/main/java/org/sopt/ticketbay/domain/user/domain/exception/UserErrorCode.java
@@ -8,6 +8,8 @@ import org.sopt.ticketbay.global.response.code.ErrorCode;
 @RequiredArgsConstructor
 public enum UserErrorCode implements ErrorCode {
 
+    // 404 잘못된 요청
+    USER_NOT_FOUND(404, "USER_404_001", "존재하지 않는 유저입니다."),
     ;
 
     private final int status;

--- a/src/main/java/org/sopt/ticketbay/domain/user/validator/UserValidator.java
+++ b/src/main/java/org/sopt/ticketbay/domain/user/validator/UserValidator.java
@@ -13,8 +13,8 @@ public class UserValidator {
 
     private UserRepository userRepository;
 
-    public void validateUser(Long eventId) {
-        if (!userRepository.existsById(eventId)) {
+    public void validateUser(Long userId) {
+        if (!userRepository.existsById(userId)) {
             throw new UserException(USER_NOT_FOUND);
         }
     }

--- a/src/main/java/org/sopt/ticketbay/domain/user/validator/UserValidator.java
+++ b/src/main/java/org/sopt/ticketbay/domain/user/validator/UserValidator.java
@@ -1,0 +1,21 @@
+package org.sopt.ticketbay.domain.user.validator;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.ticketbay.domain.user.domain.exception.UserException;
+import org.sopt.ticketbay.domain.user.repository.UserRepository;
+import org.springframework.stereotype.Component;
+
+import static org.sopt.ticketbay.domain.user.domain.exception.UserErrorCode.USER_NOT_FOUND;
+
+@RequiredArgsConstructor
+@Component
+public class UserValidator {
+
+    private UserRepository userRepository;
+
+    public void validateUser(Long eventId) {
+        if (!userRepository.existsById(eventId)) {
+            throw new UserException(USER_NOT_FOUND);
+        }
+    }
+}


### PR DESCRIPTION
# ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- [x] 리뷰어를 지정해 주세요.
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.
- [x] Assignee 지정해 주세요.
- [x] 라벨 지정해 주세요.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #7

### ⭐️ 구현 내용
- [x] 응답/에러 메세지 작성
- [x] API 구현
- [x] UserValidator 추가

---

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
1. validator 위치
 최근 목록 조회 과정에서 유저id를 받아서 해당 유저가 최근 조회한 행사 목록에 대해 조회를 하는 것이기 때문에, 유저id 값에 대한 검증이 필요하다고 생각해 UserValidator를 추가하였습니다. 다만 미리 세팅해주신 패키징 구조에서는 global에 넣기에는 User 도메인에 한정된 접근을 하기에 일단 User도메인에 validator 폴더를 추가해 여기에 구현했습니다

2. dto 
  response 구조가 History데이터를 최근에 본 이벤트 정보"들"을 조회 해오는 것이라서 List<HistoryResponse> 형태를 그대로 Response에 쓰기보다 HistoryListResponse로 한번 더 묶어서 프론트분들이 응답받았을 때 무슨 데이터인지 명확하게 알 수 있도록 작성했습니다