### PR TITLE
[FEAT] 인기 랭킹 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/ticketbay/domain/event/controller/EventController.java
+++ b/src/main/java/org/sopt/ticketbay/domain/event/controller/EventController.java
@@ -21,7 +21,7 @@ public class EventController {
 
     private final EventService eventService;
 
-    @GetMapping("event/top")
+    @GetMapping("/events/top")
     public ResponseEntity<ApiResponseBody<EventListResponse, Void>> getTopEvents(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size

--- a/src/main/java/org/sopt/ticketbay/domain/event/controller/EventController.java
+++ b/src/main/java/org/sopt/ticketbay/domain/event/controller/EventController.java
@@ -33,4 +33,4 @@ public class EventController {
         return ResponseEntity.ok(ApiResponseBody.ok(EVENT_TOP_LIST_RETRIEVED_SUCCESS, response));
     }
 }
-}
+

--- a/src/main/java/org/sopt/ticketbay/domain/event/controller/EventController.java
+++ b/src/main/java/org/sopt/ticketbay/domain/event/controller/EventController.java
@@ -1,9 +1,18 @@
 package org.sopt.ticketbay.domain.event.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.ticketbay.domain.event.controller.dto.response.EventListResponse;
+import org.sopt.ticketbay.domain.event.domain.Event;
 import org.sopt.ticketbay.domain.event.service.EventService;
+import org.sopt.ticketbay.global.response.dto.ApiResponseBody;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import static org.sopt.ticketbay.domain.event.controller.message.EventSuccessCode.EVENT_TOP_LIST_RETRIEVED_SUCCESS;
 
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
@@ -12,4 +21,16 @@ public class EventController {
 
     private final EventService eventService;
 
+    @GetMapping("event/top")
+    public ResponseEntity<ApiResponseBody<EventListResponse, Void>> getTopEvents(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Page<Event> topEventsPage = eventService.getTopEvents(page, size);
+
+        EventListResponse response = EventListResponse.fromPage(topEventsPage);
+
+        return ResponseEntity.ok(ApiResponseBody.ok(EVENT_TOP_LIST_RETRIEVED_SUCCESS, response));
+    }
+}
 }

--- a/src/main/java/org/sopt/ticketbay/domain/event/controller/dto/response/EventListResponse.java
+++ b/src/main/java/org/sopt/ticketbay/domain/event/controller/dto/response/EventListResponse.java
@@ -1,0 +1,35 @@
+package org.sopt.ticketbay.domain.event.controller.dto.response;
+
+import org.sopt.ticketbay.domain.event.domain.Event;
+
+import java.util.List;
+
+public record EventListResponse(
+        List<EventResponse> events,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages
+) {
+
+    public static EventListResponse from(List<EventResponse> events,
+                                         int page,
+                                         int size,
+                                         long totalElements,
+                                         int totalPages) {
+        return new EventListResponse(events, page, size, totalElements, totalPages);
+    }
+
+    public static EventListResponse fromPage(org.springframework.data.domain.Page<Event> pageData) {
+        List<EventResponse> eventResponses = pageData.stream()
+                .map(EventResponse::from)
+                .toList();
+        return new EventListResponse(
+                eventResponses,
+                pageData.getNumber(),
+                pageData.getSize(),
+                pageData.getTotalElements(),
+                pageData.getTotalPages()
+        );
+    }
+}

--- a/src/main/java/org/sopt/ticketbay/domain/event/controller/dto/response/EventResponse.java
+++ b/src/main/java/org/sopt/ticketbay/domain/event/controller/dto/response/EventResponse.java
@@ -7,17 +7,13 @@ import java.time.Instant;
 public record EventResponse(
         Long id,
         String name,
-        String detailName,
-        Instant eventDate,
-        long viewCount
+        String place
 ) {
     public static EventResponse from(Event event) {
         return new EventResponse(
                 event.getId(),
                 event.getName(),
-                event.getDetailName(),
-                event.getEventDate(),
-                event.getViewCount()
+                event.getPlace()
         );
     }
 }

--- a/src/main/java/org/sopt/ticketbay/domain/event/controller/dto/response/EventResponse.java
+++ b/src/main/java/org/sopt/ticketbay/domain/event/controller/dto/response/EventResponse.java
@@ -1,0 +1,23 @@
+package org.sopt.ticketbay.domain.event.controller.dto.response;
+
+import org.sopt.ticketbay.domain.event.domain.Event;
+
+import java.time.Instant;
+
+public record EventResponse(
+        Long id,
+        String name,
+        String detailName,
+        Instant eventDate,
+        long viewCount
+) {
+    public static EventResponse from(Event event) {
+        return new EventResponse(
+                event.getId(),
+                event.getName(),
+                event.getDetailName(),
+                event.getEventDate(),
+                event.getViewCount()
+        );
+    }
+}

--- a/src/main/java/org/sopt/ticketbay/domain/event/controller/message/EventSuccessCode.java
+++ b/src/main/java/org/sopt/ticketbay/domain/event/controller/message/EventSuccessCode.java
@@ -7,6 +7,7 @@ import org.sopt.ticketbay.global.response.code.SuccessCode;
 @Getter
 @RequiredArgsConstructor
 public enum EventSuccessCode implements SuccessCode {
+    EVENT_TOP_LIST_RETRIEVED_SUCCESS(200, "EVN_200_001", "성공적으로 인기 이벤트 랭킹 목록을 조회했습니다.")
 
     ;
 

--- a/src/main/java/org/sopt/ticketbay/domain/event/repository/EventRepository.java
+++ b/src/main/java/org/sopt/ticketbay/domain/event/repository/EventRepository.java
@@ -3,8 +3,7 @@ package org.sopt.ticketbay.domain.event.repository;
 import org.sopt.ticketbay.domain.event.domain.Event;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface EventRepository extends JpaRepository<Event, Long> {
+public interface EventRepository {
     Page<Event> findTopEventsByViewCount(Pageable pageable);
 }

--- a/src/main/java/org/sopt/ticketbay/domain/event/repository/EventRepository.java
+++ b/src/main/java/org/sopt/ticketbay/domain/event/repository/EventRepository.java
@@ -1,8 +1,10 @@
 package org.sopt.ticketbay.domain.event.repository;
 
 import org.sopt.ticketbay.domain.event.domain.Event;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EventRepository extends JpaRepository<Event, Long> {
-
+    Page<Event> findTopEventsByViewCount(Pageable pageable);
 }

--- a/src/main/java/org/sopt/ticketbay/domain/event/repository/EventRepositoryImpl.java
+++ b/src/main/java/org/sopt/ticketbay/domain/event/repository/EventRepositoryImpl.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Repository;
 
 @RequiredArgsConstructor
 @Repository
-public class EventRepositoyImpl {
+public class EventRepositoryImpl {
 
     private final JPAQueryFactory jpaQueryFactory;
 

--- a/src/main/java/org/sopt/ticketbay/domain/event/repository/EventRepositoyImpl.java
+++ b/src/main/java/org/sopt/ticketbay/domain/event/repository/EventRepositoyImpl.java
@@ -1,5 +1,7 @@
 package org.sopt.ticketbay.domain.event.repository;
 
+import static org.sopt.ticketbay.domain.event.domain.QEvent.event;
+
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.sopt.ticketbay.domain.event.domain.Event;
@@ -15,8 +17,6 @@ public class EventRepositoyImpl {
     private final JPAQueryFactory jpaQueryFactory;
 
     public Page<Event> findTopEventsByViewCount(Pageable pageable) {
-        QEvent event = QEvent.event;
-
         List<Event> events = jpaQueryFactory
                 .selectFrom(event)
                 .orderBy(event.viewCount.desc()) // 조회수 기준 높은 순

--- a/src/main/java/org/sopt/ticketbay/domain/event/repository/EventRepositoyImpl.java
+++ b/src/main/java/org/sopt/ticketbay/domain/event/repository/EventRepositoyImpl.java
@@ -1,0 +1,34 @@
+package org.sopt.ticketbay.domain.event.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.sopt.ticketbay.domain.event.domain.Event;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class EventRepositoyImpl {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public Page<Event> findTopEventsByViewCount(Pageable pageable) {
+        QEvent event = QEvent.event;
+
+        List<Event> events = jpaQueryFactory
+                .selectFrom(event)
+                .orderBy(event.viewCount.desc()) // 조회수 기준 높은 순
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        long total = jpaQueryFactory
+                .select(event.count())
+                .from(event)
+                .fetchOne();
+
+        return new PageImpl<>(events, pageable, total);
+    }
+}

--- a/src/main/java/org/sopt/ticketbay/domain/event/service/EventService.java
+++ b/src/main/java/org/sopt/ticketbay/domain/event/service/EventService.java
@@ -1,7 +1,10 @@
 package org.sopt.ticketbay.domain.event.service;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.ticketbay.domain.event.domain.Event;
 import org.sopt.ticketbay.domain.event.repository.EventRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -10,4 +13,7 @@ public class EventService {
 
     private final EventRepository eventRepository;
 
+    public Page<Event> getTopEvents(int page, int size) {
+        return eventRepository.findTopEventsByViewCount(PageRequest.of(page, size));
+    }
 }


### PR DESCRIPTION
# ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- [x] 리뷰어를 지정해 주세요.
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.
- [x] Assignee 지정해 주세요.
- [x] 라벨 지정해 주세요.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #10

### ⭐️ 구현 내용
- [x] 페이징 적용
- [x] API 구현
- [x] 성공 메세지 추가

---

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
1. 페이징 적용
 페이징 적용해서 1~10위 11~20위 이렇게 나눠서 보내지도록 구현했습니다. request parameter로 page, size를 받아서 페이징을 조회 및 리턴하는 형식으로 구현하였고, controller에서 받은 page, size의 단일값을 service단에서 Pagable로 변환해서 repository에서는 Pageable로 받도록 하였습니다.

2. 엔드포인트
 코드를 작성하다보니 이 API가 인기있는 이벤트 리스트를 보여주는 것이기에 "event/top" 이 엔드포인트가 "ticket/ranking"보다 좀더 직관적이고 적절하다는 생각에 고민을 하다가 "event/top" <- 이 엔드포인트로 구현했습니다. 이 두 엔드포인트에 대해서 소연님 의견은 어떤지 궁금합니다!